### PR TITLE
Change blue theme to battery green

### DIFF
--- a/style.css
+++ b/style.css
@@ -197,10 +197,10 @@ button.copy-btn {
   --page-bg:           #777777;
   --panel-bg:          #eeeeee;
   --border-color:      #cccccc;
-  --header-bg:         #007acc;
+  --header-bg:         #00cc00; /* battery green */
   --header-text:       #ffffff;
   --form-bg:           #fafafa;
-  --hover-bg:          #005a9e;
+  --hover-bg:          #009900;
   --help-bg:           #eef6fc;
   --help-border:       #9999cc;
   --table-bg:          #fafafa;


### PR DESCRIPTION
## Summary
- switch info icon color back to blue
- keep battery green tones for header and hover backgrounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a78a32d8c83288ecb9e02e08ceadb