### PR TITLE
Ensure ep4 uses qavg airflow

### DIFF
--- a/dev/energy.c
+++ b/dev/energy.c
@@ -178,8 +178,8 @@ D ep4(D F_geo, D flow, D qavg, I atemp, I Foot4) {
 	if (qavg <= 0.35) { R 0; }
 	// Tillägget kan enbart användas på grund av krav på ventilation i särskilda utrymmen som badrum, toalett och kök
 	if (!Foot4) { R 0; }
-	// får högst tillgodoräknas upp till 0,6 l/s·m²
-	if (flow > 0.6) { flow = 0.6; }
+        // q_medel får högst tillgodoräknas upp till 0,6 l/s·m²
+        if (qavg > 0.6) { qavg = 0.6; }
 	R 40 * (qavg - 0.35);
 }
 

--- a/dev/tests.c
+++ b/dev/tests.c
@@ -58,6 +58,7 @@ I THelpers() {
     if(!DEQ(ep2(0.5),6.0,0.01)){PF("ep2 FAIL\n");F++;}
     if(!DEQ(el3(1.1,0.4,100),0.12,0.01)){PF("el3 FAIL\n");F++;}
     if(!DEQ(ep4(1.1,0.5,0.4,100,1),2.0,0.01)){PF("ep4 FAIL\n");F++;}
+    if(!DEQ(ep4(1.1,0.8,0.7,100,1),10.0,0.01)){PF("ep4 cap FAIL\n");F++;}
     if(!DEQ(el5(1.1,0.5,100,1),0.36,0.01)){PF("el5 FAIL\n");F++;}
     R F;
 }

--- a/energy.js
+++ b/energy.js
@@ -136,14 +136,13 @@ function el3(F_geo, flow, atemp) {
 }
 
 function ep4(F_geo, flow, qavg, atemp, Foot4) {
-  qavg = flow; // treat instantaneous as average here
   // ... i flerbostadshus där Atemp är 50 m² eller större
   if (atemp < 50) { return 0; }
   // q_medel är uteluftsflödet i temperaturreglerade utrymmen överstiger 0,35 l/s·m²
   if (qavg <= 0.35) { return 0; }
   // Tillägget kan enbart användas på grund av krav på ventilation i särskilda utrymmen som badrum, toalett och kök
   if (!Foot4) { return 0; }
-  // får högst tillgodoräknas upp till 0,6 l/s·m²
+  // q_medel får högst tillgodoräknas upp till 0,6 l/s·m²
   if (qavg > 0.6) { qavg = 0.6; }
   return 40 * (qavg - 0.35);
 }


### PR DESCRIPTION
## Summary
- fix ep4 implementation in C and JS so the 0.6 l/s·m² cap applies to qavg
- remove flow override in JS ep4
- extend ep4 helper test to cover the cap

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bfcb740bc8328b6d2cef0f694bc3e