### PR TITLE
Add Node tests for energy.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ dev/energy
 Thumbs.db
 dev/tests
 test_output.txt
+test_js_output.txt
 
 **/Thumbs.db

--- a/energy.js
+++ b/energy.js
@@ -295,3 +295,28 @@ function printHouse(house) {
 
   printHouse(h);*/
 })();
+
+// Export for Node.js testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    EType,
+    E_wght,
+    E_name,
+    Location,
+    locations,
+    HouseType,
+    HouseType_name,
+    Energy,
+    House,
+    LimitVals,
+    elBase,
+    el1,
+    ep2,
+    el3,
+    ep4,
+    el5,
+    EPpet,
+    limit,
+    printHouse
+  };
+}

--- a/js_tests.js
+++ b/js_tests.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const energy = require('./energy.js');
+const {EType, HouseType, locations, House, EPpet, limit} = energy;
+
+function assertApprox(actual, expected, eps, label) {
+  assert.ok(Math.abs(actual - expected) <= eps, `${label}: expected ${expected} got ${actual}`);
+}
+
+const tests = [
+  function testNewHouse() {
+    const h = new House(HouseType.SMALL, 100, locations[1]);
+    assert.strictEqual(h.Rooms, 0, 'Rooms default');
+    assert.strictEqual(h.HouseHoldEnergy, 0, 'HouseHoldEnergy default');
+    assert.strictEqual(h.uval.U_roof, 0, 'uval default');
+    assert.strictEqual(h.energyusage, null, 'energyusage default');
+  },
+  function testSmallHouse() {
+    const h1 = new House(HouseType.SMALL, 100, locations[1]);
+    h1.E.heat[EType.ELECTRIC] = 120;
+    h1.E.cool[EType.FJARRKYLA] = 40;
+    assert.strictEqual(EPpet(h1), 2, 'EPpet small house');
+    const lim = limit(h1);
+    assert.strictEqual(lim.EP, 95, 'EP small house');
+    assertApprox(lim.EL, 4.5, 0.001, 'EL small house');
+    assertApprox(lim.UM, 0.30, 0.001, 'UM small house');
+    assert.strictEqual(lim.LL, -1, 'LL small house');
+  },
+  function testMultiHouse() {
+    const h2 = new House(HouseType.MULTI, 200, locations[0]);
+    h2.flow = 0.4;
+    h2.qavg = 0.4;
+    h2.foot4 = true;
+    h2.foot5 = true;
+    assert.strictEqual(EPpet(h2), 0, 'EPpet multi house');
+    const lim = limit(h2);
+    assert.strictEqual(lim.EP, 77, 'EP multi house');
+    assertApprox(lim.EL, 6.8, 0.001, 'EL multi house');
+    assertApprox(lim.UM, 0.40, 0.001, 'UM multi house');
+    assert.strictEqual(lim.LL, -1, 'LL multi house');
+  },
+  function testLocalHouse() {
+    const h3 = new House(HouseType.LOCAL, 60, locations[1]);
+    h3.qavg = 0.4;
+    h3.flow = 0.5;
+    h3.foot2 = true;
+    h3.foot3 = true;
+    assert.strictEqual(EPpet(h3), 0, 'EPpet local');
+    const lim = limit(h3);
+    assert.strictEqual(lim.EP, 72, 'EP local');
+    assertApprox(lim.EL, 4.698, 0.001, 'EL local');
+    assertApprox(lim.UM, 0.50, 0.001, 'UM local');
+    assert.strictEqual(lim.LL, -1, 'LL local');
+  },
+  function testEPRounding() {
+    const h = new House(HouseType.SMALL, 1, locations[1]);
+    h.E.heat[EType.ELECTRIC] = 50.333;
+    assert.strictEqual(EPpet(h), 90, 'EP rounding');
+  }
+];
+
+let failures = 0;
+for (const t of tests) {
+  try {
+    t();
+    console.log(`${t.name}: PASS`);
+  } catch (e) {
+    failures++;
+    console.log(`${t.name}: FAIL`);
+    console.log(e.message);
+  }
+}
+if (failures === 0) {
+  console.log('ALL JS TESTS PASSED');
+  process.exit(0);
+} else {
+  console.log(`${failures} JS TESTS FAILED`);
+  process.exit(1);
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,3 +3,6 @@
 
 gcc -o dev/tests dev/tests.c -lm
 ./dev/tests > test_output.txt
+
+# Run JavaScript tests
+node js_tests.js > test_js_output.txt


### PR DESCRIPTION
## Summary
- export energy.js functions when running under Node
- add Node-based tests mirroring browser tests
- run JS tests in `run_tests.sh`
- ignore JavaScript test output

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684bfe536ae08328903f0fc075449440