### PR TITLE
Add lockable input fields

### DIFF
--- a/style.css
+++ b/style.css
@@ -172,6 +172,17 @@ textarea#permalink {
   cursor: default;
 }
 
+
+.lock-icon {
+  margin-left: 0.25rem;
+  cursor: pointer;
+}
+
+.value-box {
+  display: inline-flex;
+  align-items: center;
+}
+
 button.clear-btn,
 button.copy-btn {
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- add `ValueBox` class and create instances when building the table
- support locking/unlocking of calculated values
- show lock icons next to inputs and style them
- update calculations to read from the new components

## Testing
- `./run_tests.sh` *(fails: 4 JS tests)*

------
https://chatgpt.com/codex/tasks/task_e_684fc9430e40832886a94a8f362062fd