### PR TITLE
Improve ValueBox visual state

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -42,6 +42,11 @@ class ValueBox {
   }
   updateVisual() {
     if (this.allowToggle) this.box.readOnly = this.locked;
+    if (this.locked) {
+      this.box.classList.add("locked");
+    } else {
+      this.box.classList.remove("locked");
+    }
     this.but.textContent = this.locked ? "🔒" : "🔓";
   }
   setCalc(v) {

--- a/style.css
+++ b/style.css
@@ -97,7 +97,7 @@ form#houseForm th {
 
 form#houseForm input[type="number"],
 form#houseForm select {
-  width: calc(100% - 0.25rem);
+  width: 100%;
   padding: 0.15rem;
   font-size: 0.9rem;
   box-sizing: border-box;
@@ -173,9 +173,15 @@ textarea#permalink {
 }
 
 
+
 .lock-icon {
-  margin-left: 0.25rem;
+  margin-left: 0;
   cursor: pointer;
+}
+
+.value-box input.locked {
+  background: #eee;
+  color: #666;
 }
 
 .value-box {


### PR DESCRIPTION
## Summary
- show greyed out appearance when ValueBox is locked
- remove spacing between input and lock button
- make energy table inputs fill the cell width

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684fdfcd00908328b69f585c3e056806