### PR TITLE
Improve calculator column

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -41,13 +41,18 @@ class ValueBox {
     this.updateVisual();
   }
   updateVisual() {
-    if (this.allowToggle) this.box.readOnly = this.locked;
+    if (this.allowToggle) {
+      this.box.disabled = this.locked;
+    } else {
+      this.box.disabled = true;
+    }
     if (this.locked) {
       this.box.classList.add("locked");
     } else {
       this.box.classList.remove("locked");
     }
-    this.but.textContent = this.locked ? "🔒" : "🔓";
+    // the button is hidden when using row-wise checkboxes, so no icon needed
+    this.but.textContent = "";
   }
   setCalc(v) {
     this.valueCalc = v;
@@ -275,7 +280,9 @@ function loadEnergyTable() {
 	const hr    = thead.insertRow();
         hr.insertCell().textContent = "";
         E_name.forEach(name => hr.insertCell().textContent = name);
-        hr.insertCell().textContent = "\uD83D\uDD12"; // lock icon header
+        const calcCell = hr.insertCell();
+        calcCell.textContent = getString("calc_icon");
+        calcCell.title = getString("calc_help");
 
 	const tbody = table.createTBody();
         const rowLocks = {};

--- a/strings.js
+++ b/strings.js
@@ -288,11 +288,22 @@ const STRINGS = {
 	},
 
 	// “?” icon character
-	info_icon: {
-		sv: "?",
-		en: "?",
-		fi: "?"
-	},
+        info_icon: {
+                sv: "?",
+                en: "?",
+                fi: "?"
+        },
+
+        calc_icon: {
+                sv: "\uD83E\uDDEE", // calculator emoji
+                en: "\uD83E\uDDEE",
+                fi: "\uD83E\uDDEE"
+        },
+        calc_help: {
+                sv: "Avmarkera för att ange värden manuellt",
+                en: "Deselect to enter values manually",
+                fi: "Poista valinta syöttääksesi arvot käsin"
+        },
 
 
 

--- a/style.css
+++ b/style.css
@@ -91,6 +91,12 @@ form#houseForm table td {
   max-width: 4rem;
 }
 
+form#houseForm table th:last-child,
+form#houseForm table td:last-child {
+  width: 3ch;
+  max-width: 3ch;
+}
+
 form#houseForm th {
   background: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- disable calculated inputs instead of using readonly
- narrow auto-calc column
- switch lock icon to a calculator and add help text
- drop unused button icon toggle
- fix Swedish and Finnish calc tooltip text

## Testing
- `./run_tests.sh`
- `node js_tests.js > test_js_output.txt` *(fails 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684fe409a8d88328b8774f8c4010e78e