### PR TITLE
Enable calculator help button and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ css could use some work
 
 ## Help-icon logic
 
-For any key `x`, a “?” help icon will be shown **if and only if** all of the following are true:
-
-1. There is an element in the DOM with `id="x_help_icon"`.  
-2. There is a matching help container with `id="x_help"`.  
-3. `STRINGS` in  `strings.js` has a non blank entry with `x_help`
+For any key `x` where `strings.js` defines a non-empty `x_help` entry, the
+interface will automatically generate a “?” icon and a matching help box. If the
+elements `x_help_icon` or `x_help` do not already exist in the DOM they will be
+created next to the label (or the element itself) and wired to show the help
+text on click.
 
 
 

--- a/glue.js
+++ b/glue.js
@@ -281,7 +281,10 @@ function loadEnergyTable() {
         hr.insertCell().textContent = "";
         E_name.forEach(name => hr.insertCell().textContent = name);
         const calcCell = hr.insertCell();
-        calcCell.textContent = getString("calc_icon");
+        const calcSpan = document.createElement("span");
+        calcSpan.id = "calc";
+        calcSpan.textContent = getString("calc_icon");
+        calcCell.appendChild(calcSpan);
         calcCell.title = getString("calc_help");
 
 	const tbody = table.createTBody();
@@ -534,6 +537,7 @@ function main(){
 
     loadGeography();
         loadEnergyTable();
+        applyLanguage(); // add help icons for dynamically created elements
         loadTvvDropdown();
 
 	prefillFromURL();


### PR DESCRIPTION
## Summary
- document automatic help icon generation in README
- create a calculator help icon in the energy table
- refresh language after creating the table so dynamic elements get help icons

## Testing
- `./run_tests.sh`
- `cat test_output.txt`
- `cat test_js_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_684fe79277c88328b2b1568c281a8aa7