### PR TITLE
Update calc help message

### DIFF
--- a/strings.js
+++ b/strings.js
@@ -300,9 +300,9 @@ const STRINGS = {
                 fi: "\uD83E\uDDEE"
         },
         calc_help: {
-                sv: "Avmarkera för att ange värden manuellt",
-                en: "Deselect to enter values manually",
-                fi: "Poista valinta syöttääksesi arvot käsin"
+                sv: "Markerad: använd beräknade eller förinställda värden. Avmarkerad: ange manuellt",
+                en: "Checked: use calculated or preset values. Unchecked: enter values manually",
+                fi: "Valittuna: käytä laskettuja tai esiasetettuja arvoja. Ei valittuna: syötä arvot käsin"
         },
 
 


### PR DESCRIPTION
## Summary
- clarify calculator checkbox tooltip text in multiple languages using literal non-ASCII characters

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fed27c8dc83288f168191a1a727ae