### PR TITLE
Add energy deduction UI

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -114,6 +114,25 @@
 
                                 </details>
 
+<details class="input-section" open>
+    <summary id="section_energyinput_heading"></summary>
+    <label for="heatEnergy" id="lbl_heatEnergy"><span id="heatEnergy_label"></span></label>
+    <input type="number" id="heatEnergy" name="heatEnergy" step="any">
+    <select id="heatEnergyType" name="heatEnergyType"></select>
+</details>
+<details class="input-section" open>
+    <summary id="section_deductions_heading"></summary>
+    <label for="dedPersons" id="lbl_dedPersons"><span id="dedPersons_label"></span></label>
+    <input type="number" id="dedPersons" name="dedPersons" min="0">
+    <br />
+    <label for="dedPersonHeat" id="lbl_dedPersonHeat"><span id="dedPersonHeat_label"></span></label>
+    <input type="number" id="dedPersonHeat" name="dedPersonHeat" value="80" step="any">
+    <br />
+    <label for="dedTimeHours" id="lbl_dedTime"><span id="dedTime_label"></span></label>
+    <input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"> h/d
+    <input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"> d/v
+    <input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"> v/år
+</details>
                                 </br>
 
 

--- a/glue.js
+++ b/glue.js
@@ -18,6 +18,13 @@ const copy     	= $("copy_button");
 const print       = $("print_button");    
 const form     	  = $("houseForm");
 const footnoteBox = $("footnoteBox");
+const heatEnergyInput = $("heatEnergy");
+const heatEnergyType = $("heatEnergyType");
+const dedPersons = $("dedPersons");
+const dedPersonHeat = $("dedPersonHeat");
+const dedTimeHours = $("dedTimeHours");
+const dedTimeDays = $("dedTimeDays");
+const dedTimeWeeks = $("dedTimeWeeks");
 const foot2Lbl    = $("lbl_foot2");
 const foot3Lbl    = $("lbl_foot3");
 const foot4Lbl    = $("lbl_foot4");
@@ -106,6 +113,9 @@ function registerListeners(){
         type.addEventListener("change", () => { updateFootnotes(); calculate(); });
         if (tvvSel) tvvSel.addEventListener("change", calculate);
         form.addEventListener("input", calculate);
+    if (heatEnergyInput) heatEnergyInput.addEventListener("input", updateDeductions);
+    if (heatEnergyType) heatEnergyType.addEventListener("change", updateDeductions);
+    [dedPersons,dedPersonHeat,dedTimeHours,dedTimeDays,dedTimeWeeks].forEach(el=>{ if(el) el.addEventListener("input", updateDeductions);});
 
 	//clear
 	clear.addEventListener("click", clearUI);
@@ -265,6 +275,12 @@ function loadTvvDropdown() {
         tvvSel.innerHTML = "";
         tvvFactors.forEach((f, idx) => { tvvSel.add(new Option(f.name, idx)); });
 }
+function loadHeatEnergyDropdown() {
+    if (!heatEnergyType) return;
+    heatEnergyType.innerHTML = "";
+    E_name.forEach((n, i) => { heatEnergyType.add(new Option(n, i)); });
+}
+
 
 function loadEnergyTable() {
         const table = $("energyTable");
@@ -317,7 +333,7 @@ function loadEnergyTable() {
 		}
 
                 // add cells
-                const lockRow = (key === "watr");
+                const lockRow = true;
                 const rowBoxes = [];
                 for (let i = 0; i < EType.E_TYPE_COUNT; i++) {
                         const c = row.insertCell();
@@ -402,6 +418,21 @@ function updateTvvRow() {
     }
   }
 }
+function updateDeductions() {
+    if (!window.heatEls) return;
+    const energy = parseFloat(heatEnergyInput.value) || 0;
+    const idx = parseInt(heatEnergyType.value, 10) || 0;
+    const persons = parseFloat(dedPersons.value) || 0;
+    const perHeat = parseFloat(dedPersonHeat.value) || 0;
+    const hours = parseFloat(dedTimeHours.value) || 0;
+    const days = parseFloat(dedTimeDays.value) || 0;
+    const weeks = parseFloat(dedTimeWeeks.value) || 0;
+    const ded = persons * perHeat * hours * days * weeks / 1000;
+    const res = energy - ded;
+    const vb = window.heatEls[idx];
+    if (vb) vb.setCalc(res ? res.toFixed(1) : "");
+}
+
 
 
 //Connect to energy.js and display output, and build the perma link
@@ -538,11 +569,13 @@ function main(){
         applyLanguage(); // add help icons for dynamically created elements
         loadTvvDropdown();
 
+    loadHeatEnergyDropdown();
 	prefillFromURL();
 
         registerListeners();
 
         updateFootnotes();
+        updateDeductions();
         updateTvvRow();
         calculate();
 }

--- a/strings.js
+++ b/strings.js
@@ -71,6 +71,41 @@ const STRINGS = {
                 fi: "Energiatekijät"
         },
 
+        section_energyinput_heading: {
+                sv: "Energiinmatning",
+                en: "Energy Input",
+                fi: "Energian syöttö"
+        },
+        heatEnergy_label: {
+                sv: "Värmeenergi (kWh):",
+                en: "Heating energy:",
+                fi: "Lämmitysenergia:"
+        },
+        heatEnergyType_label: {
+                sv: "Typ:",
+                en: "Type:",
+                fi: "Tyyppi:"
+        },
+        section_deductions_heading: {
+                sv: "Avdrag",
+                en: "Deductions",
+                fi: "Vähennykset"
+        },
+        dedPersons_label: {
+                sv: "Personer:",
+                en: "People:",
+                fi: "Henkilöt:"
+        },
+        dedPersonHeat_label: {
+                sv: "Personvärme (W):",
+                en: "Person heat (W):",
+                fi: "Henkilölämpö (W):"
+        },
+        dedTime_label: {
+                sv: "Tid (h/d/v):",
+                en: "Time (h/d/w):",
+                fi: "Aika (h/p/v):"
+        },
 	// Footnotes heading + labels
 	footnotes_heading: {
 		sv: "Extra ventilationsfotnoter (endast flerbostadshus):",


### PR DESCRIPTION
## Summary
- add energy input and deductions panels to UI
- lock all energy table rows by default
- populate dropdown for energy type
- compute heat deductions based on input
- support new UI strings

## Testing
- `./run_tests.sh` *(C tests pass; JS tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684fec9bafd48328bdc5f5121a5e79a9