### PR TITLE
UI improvements and table fixes

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -84,6 +84,12 @@
                                                 <span id="atemp_label"></span>
                                         </label>
                                         <input type="number" id="atemp" name="atemp" min="0">
+
+                                        <br />
+                                        <label for="rooms" id="lbl_rooms">
+                                                <span id="rooms_label"></span>
+                                        </label>
+                                        <input type="number" id="rooms" name="rooms" min="0" step="1">
                                 </details>
 
                                 <details class="input-section" open>
@@ -95,24 +101,6 @@
                                         <select id="tvvType" name="tvvType"></select>
                                 </details>
 
-                                <details class="input-section" open>
-                                        <summary id="section_energy_heading"></summary>
-
-                                        <label id="energy_table_label"></label><br />
-
-                                        <!-- Lock improbable combos -->
-                                        <script>
-                                                const LOCKED_COMBINATIONS = [
-                                                        { measureKey: "heat", sourceIndex: EType.FJARRKYLA },
-                                                        { measureKey: "cool", sourceIndex: EType.FJARRVARME }
-                                                ];
-                                        </script>
-                                        <!--(table built in code)-->
-                                        <table id="energyTable"></table>
-                                        <div id="energyRowHelpBox" class="help-box"></div>
-                                        <div id="calc_help" class="help-box"></div>
-
-                                </details>
 
 <details class="input-section" open>
     <summary id="section_energyinput_heading"></summary>
@@ -133,6 +121,25 @@
     <input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"> d/v
     <input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"> v/år
 </details>
+
+                                <details class="input-section" open>
+                                        <summary id="section_energy_heading"></summary>
+
+                                        <label id="energy_table_label"></label><br />
+
+                                        <!-- Lock improbable combos -->
+                                        <script>
+                                                const LOCKED_COMBINATIONS = [
+                                                        { measureKey: "heat", sourceIndex: EType.FJARRKYLA },
+                                                        { measureKey: "cool", sourceIndex: EType.FJARRVARME }
+                                                ];
+                                        </script>
+                                        <!--(table built in code)-->
+                                        <table id="energyTable"></table>
+                                        <div id="energyRowHelpBox" class="help-box"></div>
+                                        <div id="calc_help" class="help-box"></div>
+
+                                </details>
                                 </br>
 
 

--- a/glue.js
+++ b/glue.js
@@ -7,6 +7,7 @@ const $ = id => document.getElementById(id);
 const geo      = $("geography");
 const type     = $("housetype");
 const at       = $("atemp");
+const rooms    = $("rooms");
 const fl       = $("flow");
 const tvvSel   = $("tvvType");
 const f2       = $("foot2");
@@ -31,6 +32,13 @@ const foot4Lbl    = $("lbl_foot4");
 const foot5Lbl    = $("lbl_foot5");
 const outEP    = $("ep_label"), limitsT  = $("limitsTable");
 const table = $("energyTable");
+const ROOMS_TO_PERSONS = [1.42, 1.63, 2.18, 2.79, 3.51];
+
+function personsFromRooms(n) {
+    if (!n || n <= 0) return 0;
+    if (n >= 5) return ROOMS_TO_PERSONS[4];
+    return ROOMS_TO_PERSONS[n - 1];
+}
 class ValueBox {
   constructor(box, but, locked = true, allowToggle = true) {
     this.box = box;
@@ -116,6 +124,11 @@ function registerListeners(){
     if (heatEnergyInput) heatEnergyInput.addEventListener("input", updateDeductions);
     if (heatEnergyType) heatEnergyType.addEventListener("change", updateDeductions);
     [dedPersons,dedPersonHeat,dedTimeHours,dedTimeDays,dedTimeWeeks].forEach(el=>{ if(el) el.addEventListener("input", updateDeductions);});
+    if (rooms) rooms.addEventListener("input", () => {
+        const r = parseInt(rooms.value, 10);
+        dedPersons.value = personsFromRooms(r).toFixed(2);
+        updateDeductions();
+    });
 
 	//clear
 	clear.addEventListener("click", clearUI);
@@ -360,6 +373,12 @@ function loadEnergyTable() {
                 chk.addEventListener("change", () => {
                         rowBoxes.forEach(vb => {
                                 if (!vb.allowToggle) return;
+                                if (chk.checked) {
+                                        vb.valueInp = vb.box.value;
+                                        vb.box.value = vb.valueCalc;
+                                } else {
+                                        vb.valueCalc = vb.box.value;
+                                }
                                 vb.locked = chk.checked;
                                 vb.updateVisual();
                         });
@@ -542,6 +561,11 @@ function prefillFromURL() {
         geo.value = params.get("geography") || "Åland";
         type.value = params.get("housetype") || "SMALL";
         at.value = params.get("atemp") || "";
+        rooms.value = params.get("rooms") || "";
+        if (rooms.value) {
+                const r = parseInt(rooms.value, 10);
+                dedPersons.value = personsFromRooms(r).toFixed(2);
+        }
         fl.value = params.get("flow") || "";
         if (tvvSel) tvvSel.value = params.get("tvv") || "0";
 

--- a/strings.js
+++ b/strings.js
@@ -185,7 +185,12 @@ const STRINGS = {
                 en: "The area of all floors, attic, and basement for temperature‐controlled spaces intended to be heated above 10 °C, bounded by the interior of the building envelope. Area occupied by interior walls, stair openings, shafts, etc., is included; garage area (inside the building) is not counted.",
                 fi: "Lämpötilasäädeltyjen tilojen pinta‐ala, mukaan lukien kaikki kerrokset, yläkerrat ja kellarit, jotka on tarkoitus lämmittää yli 10 °C, sisäisen rakennuskuoren sisällä. Sisäseinien, portaiden, hormien jne. pinta‐ala sisältyy; autotallin pinta‐alaa ei lasketa."
         },
-
+        rooms_label: {
+                sv: "Rum + kök:",
+                en: "Rooms + kitchen:",
+                fi: "Huoneet + keittiö:"
+        },
+        
         tvvType_label: {
                 sv: "Tappvarmvattenkälla:",
                 en: "Hot water source:",
@@ -335,9 +340,9 @@ const STRINGS = {
                 fi: "\uD83E\uDDEE"
         },
         calc_help: {
-                sv: "Markerad: använd beräknade eller förinställda värden. Avmarkerad: ange manuellt",
-                en: "Checked: use calculated or preset values. Unchecked: enter values manually",
-                fi: "Valittuna: käytä laskettuja tai esiasetettuja arvoja. Ei valittuna: syötä arvot käsin"
+                sv: "Markerad: använd beräknade eller förinställda värden.<br>Avmarkerad: ange manuellt",
+                en: "Checked: use calculated or preset values.<br>Unchecked: enter values manually",
+                fi: "Valittuna: käytä laskettuja tai esiasetettuja arvoja.<br>Ei valittuna: syötä arvot käsin"
         },
 
 

--- a/style.css
+++ b/style.css
@@ -93,8 +93,8 @@ form#houseForm table td {
 
 form#houseForm table th:last-child,
 form#houseForm table td:last-child {
-  width: 3ch;
-  max-width: 3ch;
+  width: 4ch;
+  max-width: 4ch;
 }
 
 form#houseForm th {
@@ -305,7 +305,7 @@ th, td {
 
 #energyTable th:last-child,
 #energyTable td:last-child {
-  width: 3rem;
+  width: 3.5rem;
 }
 
 th {


### PR DESCRIPTION
## Summary
- add room count input and compute people automatically
- move energy table to last panel
- reset energy table values when row lock toggled
- tweak calculator tooltip and column width
- widen energy table column for help icon

## Testing
- `bash -x run_tests.sh` *(fails: JS tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684fefdac8e08328a671bfd4fe075bf9