### PR TITLE
Add personer help and spacing tweak

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -117,9 +117,9 @@
     <input type="number" id="dedPersonHeat" name="dedPersonHeat" value="80" step="any">
     <br />
     <label for="dedTimeHours" id="lbl_dedTime"><span id="dedTime_label"></span></label>
-    <input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"> h/d
-    <input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"> d/v
-    <input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"> v/år
+    <input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"> <span class="time-unit">h/d</span>
+    <input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"> <span class="time-unit">d/v</span>
+    <input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"> <span class="time-unit">v/år</span>
 </details>
 
                                 <details class="input-section" open>

--- a/strings.js
+++ b/strings.js
@@ -96,6 +96,11 @@ const STRINGS = {
                 en: "People:",
                 fi: "Henkilöt:"
         },
+        dedPersons_help: {
+                sv: "Tabell 6:3 – Värden för beräkning av antal personer i bostäder<br><table><tr><th>Antal rum och kök</th><th>Antal personer</th></tr><tr><td>1<sup>1</sup></td><td>1,42</td></tr><tr><td>2</td><td>1,63</td></tr><tr><td>3</td><td>2,18</td></tr><tr><td>4</td><td>2,79</td></tr><tr><td>5+</td><td>3,51</td></tr></table><p><sup>1</sup> Inklusive 1 rum och kokvrå</p>",
+                en: "Table 6:3 – Values for calculating number of persons in dwellings<br><table><tr><th>Rooms + kitchen</th><th>People</th></tr><tr><td>1<sup>1</sup></td><td>1.42</td></tr><tr><td>2</td><td>1.63</td></tr><tr><td>3</td><td>2.18</td></tr><tr><td>4</td><td>2.79</td></tr><tr><td>5+</td><td>3.51</td></tr></table><p><sup>1</sup> Includes 1 room with kitchenette</p>",
+                fi: "Taulukko 6:3 – Arvot henkilömäärän laskentaan asunnoissa<br><table><tr><th>Huoneet ja keittiö</th><th>Henkilöt</th></tr><tr><td>1<sup>1</sup></td><td>1,42</td></tr><tr><td>2</td><td>1,63</td></tr><tr><td>3</td><td>2,18</td></tr><tr><td>4</td><td>2,79</td></tr><tr><td>5+</td><td>3,51</td></tr></table><p><sup>1</sup> Sisältää 1 huoneen ja keittokomeron</p>"
+        },
         dedPersonHeat_label: {
                 sv: "Personvärme (W):",
                 en: "Person heat (W):",

--- a/style.css
+++ b/style.css
@@ -178,6 +178,10 @@ textarea#permalink {
   cursor: default;
 }
 
+.time-unit {
+  margin-right: 0.5rem;
+}
+
 
 
 .lock-icon {


### PR DESCRIPTION
## Summary
- show help table for person count
- tweak time input spacing for clarity

## Testing
- `gcc -o dev/tests dev/tests.c -lm`
- `./dev/tests > test_output.txt`
- `node js_tests.js > test_js_output.txt` *(fails: `4 JS TESTS FAILED`)*

------
https://chatgpt.com/codex/tasks/task_e_684ff24f7fe88328bb1f2322d0fada1f