### PR TITLE
Refactor locked energy combos

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -127,13 +127,6 @@
 
                                         <label id="energy_table_label"></label><br />
 
-                                        <!-- Lock improbable combos -->
-                                        <script>
-                                                const LOCKED_COMBINATIONS = [
-                                                        { measureKey: "heat", sourceIndex: EType.FJARRKYLA },
-                                                        { measureKey: "cool", sourceIndex: EType.FJARRVARME }
-                                                ];
-                                        </script>
                                         <!--(table built in code)-->
                                         <table id="energyTable"></table>
                                         <div id="energyRowHelpBox" class="help-box"></div>

--- a/glue.js
+++ b/glue.js
@@ -32,6 +32,13 @@ const outEP    = $("ep_label"), limitsT  = $("limitsTable");
 const table = $("energyTable");
 const ROOMS_TO_PERSONS = [1.42, 1.63, 2.18, 2.79, 3.51];
 
+// Lock improbable energy source combinations
+const LOCKED_COMBINATIONS = [
+  { measureKey: "heat", sourceIndex: EType.FJARRKYLA },
+  { measureKey: "cool", sourceIndex: EType.FJARRVARME }
+];
+window.LOCKED_COMBINATIONS = LOCKED_COMBINATIONS;
+
 function personsFromRooms(n) {
     if (!n || n <= 0) return 0;
     if (n >= 5) return ROOMS_TO_PERSONS[4];


### PR DESCRIPTION
## Summary
- move `LOCKED_COMBINATIONS` from `energy.html` to `glue.js`
- keep it globally accessible and build the energy table without inline JS

## Testing
- `bash run_tests.sh` *(fails: testSmallHouse, testMultiHouse, testLocalHouse, testEPRounding)*

------
https://chatgpt.com/codex/tasks/task_e_684ff4b945e88328ad15b02a987b6bde