### PR TITLE
UI cleanup for energy inputs

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -92,28 +92,36 @@
                                         <input type="number" id="rooms" name="rooms" min="0" step="1">
                                 </details>
 
-                                <details class="input-section" open>
-                                        <summary id="section_tvv_heading"></summary>
-
-                                        <label for="tvvType" id="lbl_tvvType">
-                                                <span id="tvvType_label"></span>
-                                        </label>
-                                        <select id="tvvType" name="tvvType"></select>
-                                </details>
-
-
 <details class="input-section" open>
     <summary id="section_energyinput_heading"></summary>
-    <label for="heatEnergy" id="lbl_heatEnergy"><span id="heatEnergy_label"></span></label>
-    <input type="number" id="heatEnergy" name="heatEnergy" step="any">
-    <select id="heatEnergyType" name="heatEnergyType"></select>
+    <label id="lbl_heatEnergy">
+        <span id="heatEnergy_label"></span>
+        <input type="number" id="heatEnergy" name="heatEnergy" step="any">
+        <select id="heatEnergyType" name="heatEnergyType"></select>
+    </label>
+    <br />
+    <label id="lbl_coolEnergy">
+        <span id="coolEnergy_label"></span>
+        <input type="number" id="coolEnergy" name="coolEnergy" step="any">
+        <select id="coolEnergyType" name="coolEnergyType"></select>
+    </label>
+    <br />
+    <label id="lbl_tvvType">
+        <span id="tvvType_label"></span>
+        <select id="tvvType" name="tvvType"></select>
+    </label>
+    <br />
+    <label id="lbl_fastEnergy">
+        <span id="fastEnergy_label"></span>
+        <input type="number" id="fastEnergy" name="fastEnergy" step="any">
+        <select id="fastEnergyType" name="fastEnergyType"></select>
+    </label>
 </details>
 <details class="input-section" open>
     <summary id="section_deductions_heading"></summary>
     <label for="dedPersons" id="lbl_dedPersons"><span id="dedPersons_label"></span></label>
     <input type="number" id="dedPersons" name="dedPersons" min="0">
-    <br />
-    <label for="dedPersonHeat" id="lbl_dedPersonHeat"><span id="dedPersonHeat_label"></span></label>
+    <label for="dedPersonHeat" id="lbl_dedPersonHeat" style="margin-left:0.5rem;"><span id="dedPersonHeat_label"></span></label>
     <input type="number" id="dedPersonHeat" name="dedPersonHeat" value="80" step="any">
     <br />
     <label for="dedTimeHours" id="lbl_dedTime"><span id="dedTime_label"></span></label>

--- a/glue.js
+++ b/glue.js
@@ -8,6 +8,10 @@ const at       = $("atemp");
 const rooms    = $("rooms");
 const fl       = $("flow");
 const tvvSel   = $("tvvType");
+const coolEnergyInput = $("coolEnergy");
+const coolEnergyType  = $("coolEnergyType");
+const fastEnergyInput = $("fastEnergy");
+const fastEnergyType  = $("fastEnergyType");
 const f2       = $("foot2");
 const f3       = $("foot3");
 const f4       = $("foot4");
@@ -32,11 +36,8 @@ const outEP    = $("ep_label"), limitsT  = $("limitsTable");
 const table = $("energyTable");
 const ROOMS_TO_PERSONS = [1.42, 1.63, 2.18, 2.79, 3.51];
 
-// Lock improbable energy source combinations
-const LOCKED_COMBINATIONS = [
-  { measureKey: "heat", sourceIndex: EType.FJARRKYLA },
-  { measureKey: "cool", sourceIndex: EType.FJARRVARME }
-];
+// Lock improbable energy source combinations (none currently)
+const LOCKED_COMBINATIONS = [];
 window.LOCKED_COMBINATIONS = LOCKED_COMBINATIONS;
 
 function personsFromRooms(n) {
@@ -92,6 +93,7 @@ class ValueBox {
     }
     this.locked = !this.locked;
     this.updateVisual();
+    calculate();
   }
   getValue() {
     return this.locked ? this.valueCalc : this.box.value;
@@ -255,6 +257,10 @@ function registerListeners(){
         form.addEventListener("input", calculate);
     if (heatEnergyInput) heatEnergyInput.addEventListener("input", updateDeductions);
     if (heatEnergyType) heatEnergyType.addEventListener("change", updateDeductions);
+    if (coolEnergyInput) coolEnergyInput.addEventListener("input", updateDeductions);
+    if (coolEnergyType) coolEnergyType.addEventListener("change", updateDeductions);
+    if (fastEnergyInput) fastEnergyInput.addEventListener("input", updateDeductions);
+    if (fastEnergyType) fastEnergyType.addEventListener("change", updateDeductions);
     [dedPersons,dedPersonHeat,dedTimeHours,dedTimeDays,dedTimeWeeks].forEach(el=>{ if(el) el.addEventListener("input", updateDeductions);});
     if (rooms) rooms.addEventListener("input", () => {
         const r = parseInt(rooms.value, 10);
@@ -303,10 +309,10 @@ function loadTvvDropdown() {
         tvvSel.innerHTML = "";
         tvvFactors.forEach((f, idx) => { tvvSel.add(new Option(f.name, idx)); });
 }
-function loadHeatEnergyDropdown() {
-    if (!heatEnergyType) return;
-    heatEnergyType.innerHTML = "";
-    E_name.forEach((n, i) => { heatEnergyType.add(new Option(n, i)); });
+function loadEnergyTypeDropdown(sel) {
+    if (!sel) return;
+    sel.innerHTML = "";
+    E_name.forEach((n, i) => { sel.add(new Option(n, i)); });
 }
 
 
@@ -397,6 +403,7 @@ function loadEnergyTable() {
                                 vb.locked = chk.checked;
                                 vb.updateVisual();
                         });
+                        calculate();
                 });
                 lockCell.appendChild(chk);
                 measureBoxes[key] = rowBoxes;
@@ -468,6 +475,20 @@ function updateDeductions() {
     const res = energy - ded;
     const vb = window.heatEls[idx];
     if (vb) vb.setCalc(res ? res.toFixed(1) : "");
+
+    if (coolEnergyInput && coolEnergyType && window.coolEls) {
+        const ce = parseFloat(coolEnergyInput.value) || 0;
+        const ci = parseInt(coolEnergyType.value, 10) || 0;
+        const cvb = window.coolEls[ci];
+        if (cvb) cvb.setCalc(ce ? ce.toFixed(1) : "");
+    }
+
+    if (fastEnergyInput && fastEnergyType && window.fastEls) {
+        const fe = parseFloat(fastEnergyInput.value) || 0;
+        const fi = parseInt(fastEnergyType.value, 10) || 0;
+        const fvb = window.fastEls[fi];
+        if (fvb) fvb.setCalc(fe ? fe.toFixed(1) : "");
+    }
 }
 
 
@@ -613,7 +634,9 @@ function main(){
         applyLanguage(); // add help icons for dynamically created elements
         loadTvvDropdown();
 
-    loadHeatEnergyDropdown();
+    loadEnergyTypeDropdown(heatEnergyType);
+    loadEnergyTypeDropdown(coolEnergyType);
+    loadEnergyTypeDropdown(fastEnergyType);
 	prefillFromURL();
 
         registerListeners();

--- a/strings.js
+++ b/strings.js
@@ -86,6 +86,16 @@ const STRINGS = {
                 en: "Type:",
                 fi: "Tyyppi:"
         },
+        coolEnergy_label: {
+                sv: "Kylenergi (kWh):",
+                en: "Cooling energy:",
+                fi: "Jäähdytysenergia:"
+        },
+        fastEnergy_label: {
+                sv: "Fastighetsenergi (kWh):",
+                en: "Facility energy:",
+                fi: "Kiinteistöenergia:"
+        },
         section_deductions_heading: {
                 sv: "Avdrag",
                 en: "Deductions",


### PR DESCRIPTION
## Summary
- reorganize energy input area and place heating, cooling, TVV and facility energy on one panel
- remove hardcoded locked combinations and recalc when locking rows
- run calculations when values are locked/unlocked
- keep deduction person count and watts per person on one line

## Testing
- `bash run_tests.sh`
- `tail -n 5 test_output.txt`
- `tail -n 5 test_js_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_684ff70e43a48328ad6cb1ff5c0124ab