### PR TITLE
Add energy input table layout

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -94,28 +94,50 @@
 
 <details class="input-section" open>
     <summary id="section_energyinput_heading"></summary>
-    <label id="lbl_heatEnergy">
-        <span id="heatEnergy_label"></span>
-        <input type="number" id="heatEnergy" name="heatEnergy" step="any">
-        <select id="heatEnergyType" name="heatEnergyType"></select>
-    </label>
-    <br />
-    <label id="lbl_coolEnergy">
-        <span id="coolEnergy_label"></span>
-        <input type="number" id="coolEnergy" name="coolEnergy" step="any">
-        <select id="coolEnergyType" name="coolEnergyType"></select>
-    </label>
-    <br />
-    <label id="lbl_tvvType">
-        <span id="tvvType_label"></span>
-        <select id="tvvType" name="tvvType"></select>
-    </label>
-    <br />
-    <label id="lbl_fastEnergy">
-        <span id="fastEnergy_label"></span>
-        <input type="number" id="fastEnergy" name="fastEnergy" step="any">
-        <select id="fastEnergyType" name="fastEnergyType"></select>
-    </label>
+    <table id="energyInputTable">
+        <tr>
+            <td>
+                <label for="heatEnergy" id="lbl_heatEnergy"><span id="heatEnergy_label"></span></label>
+            </td>
+            <td>
+                <input type="number" id="heatEnergy" name="heatEnergy" step="any">
+            </td>
+            <td>
+                <select id="heatEnergyType" name="heatEnergyType"></select>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="coolEnergy" id="lbl_coolEnergy"><span id="coolEnergy_label"></span></label>
+            </td>
+            <td>
+                <input type="number" id="coolEnergy" name="coolEnergy" step="any">
+            </td>
+            <td>
+                <select id="coolEnergyType" name="coolEnergyType"></select>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="tvvType" id="lbl_tvvType"><span id="tvvType_label"></span></label>
+            </td>
+            <td></td>
+            <td>
+                <select id="tvvType" name="tvvType"></select>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="fastEnergy" id="lbl_fastEnergy"><span id="fastEnergy_label"></span></label>
+            </td>
+            <td>
+                <input type="number" id="fastEnergy" name="fastEnergy" step="any">
+            </td>
+            <td>
+                <select id="fastEnergyType" name="fastEnergyType"></select>
+            </td>
+        </tr>
+    </table>
 </details>
 <details class="input-section" open>
     <summary id="section_deductions_heading"></summary>

--- a/style.css
+++ b/style.css
@@ -319,6 +319,16 @@ th, td {
   width: 3.5rem;
 }
 
+/* Energy input table without borders */
+#energyInputTable {
+  border-collapse: collapse;
+  width: auto;
+}
+#energyInputTable td {
+  border: none;
+  padding: 0.25rem 0.5rem 0.25rem 0;
+}
+
 th {
   background: var(--table-header-bg);
 }


### PR DESCRIPTION
## Summary
- align energy inputs in a table
- style energy input table with no borders

## Testing
- `./run_tests.sh` *(fails: 4 JS tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ff9382ed083289764f2d1eb0b46e6