### PR TITLE
Improve deduction lock UI

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -143,15 +143,15 @@
     <summary id="section_deductions_heading"></summary>
     <span class="ded-pair">
         <label for="dedPersons" id="lbl_dedPersons"><span id="dedPersons_label"></span></label>
-        <span class="value-box"><input type="number" id="dedPersons" name="dedPersons" min="0"><button type="button" class="lock-icon"></button></span>
+        <span class="value-box"><input type="number" id="dedPersons" name="dedPersons" min="0"><button type="button" class="lock-icon" aria-label="Toggle lock"></button></span>
         <label for="dedPersonHeat" id="lbl_dedPersonHeat" style="margin-left:0.5rem;"><span id="dedPersonHeat_label"></span></label>
-        <span class="value-box"><input type="number" id="dedPersonHeat" name="dedPersonHeat" step="any"><button type="button" class="lock-icon"></button></span>
+        <span class="value-box"><input type="number" id="dedPersonHeat" name="dedPersonHeat" step="any"><button type="button" class="lock-icon" aria-label="Toggle lock"></button></span>
     </span>
     <br />
     <label for="dedTimeHours" id="lbl_dedTime"><span id="dedTime_label"></span></label>
-    <span class="value-box"><input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"><button type="button" class="lock-icon"></button></span> <span class="time-unit">h/d</span>
-    <span class="value-box"><input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"><button type="button" class="lock-icon"></button></span> <span class="time-unit">d/v</span>
-    <span class="value-box"><input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"><button type="button" class="lock-icon"></button></span> <span class="time-unit">v/år</span>
+    <span class="value-box"><input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"><button id="dedTimeLock" type="button" class="lock-icon" aria-label="Toggle lock"></button></span> <span class="time-unit">h/d</span>
+    <span class="value-box"><input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"></span> <span class="time-unit">d/v</span>
+    <span class="value-box"><input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"></span> <span class="time-unit">v/år</span>
 </details>
 
                                 <details class="input-section" open>

--- a/glue.js
+++ b/glue.js
@@ -28,6 +28,7 @@ const dedPersonHeat = $("dedPersonHeat");
 const dedTimeHours = $("dedTimeHours");
 const dedTimeDays = $("dedTimeDays");
 const dedTimeWeeks = $("dedTimeWeeks");
+const dedTimeLock = $("dedTimeLock");
 let dedPersonsVB, dedPersonHeatVB, dedTimeHoursVB, dedTimeDaysVB, dedTimeWeeksVB;
 const foot2Lbl    = $("lbl_foot2");
 const foot3Lbl    = $("lbl_foot3");
@@ -77,8 +78,13 @@ class ValueBox {
     } else {
       this.box.classList.remove("locked");
     }
-    // the button is hidden when using row-wise checkboxes, so no icon needed
-    this.but.textContent = "";
+    // show an icon on toggleable buttons
+    if (this.allowToggle) {
+      this.but.textContent = this.locked ? getString("calc_icon") : getString("pen_icon");
+      const tip = this.locked ? getString("calc_tooltip") : getString("pen_tooltip");
+      this.but.title = tip;
+      this.but.setAttribute("aria-label", tip);
+    }
   }
   setCalc(v) {
     this.valueCalc = v;
@@ -432,17 +438,14 @@ function initDeductions() {
         const btn = dedPersonHeat.parentElement.querySelector("button");
         dedPersonHeatVB = new ValueBox(dedPersonHeat, btn, true, true);
     }
-    if (dedTimeHours) {
-        const btn = dedTimeHours.parentElement.querySelector("button");
-        dedTimeHoursVB = new ValueBox(dedTimeHours, btn, true, true);
+    if (dedTimeLock && dedTimeHours) {
+        dedTimeHoursVB = new ValueBox(dedTimeHours, dedTimeLock, true, true);
     }
-    if (dedTimeDays) {
-        const btn = dedTimeDays.parentElement.querySelector("button");
-        dedTimeDaysVB = new ValueBox(dedTimeDays, btn, true, true);
+    if (dedTimeLock && dedTimeDays) {
+        dedTimeDaysVB = new ValueBox(dedTimeDays, dedTimeLock, true, true);
     }
-    if (dedTimeWeeks) {
-        const btn = dedTimeWeeks.parentElement.querySelector("button");
-        dedTimeWeeksVB = new ValueBox(dedTimeWeeks, btn, true, true);
+    if (dedTimeLock && dedTimeWeeks) {
+        dedTimeWeeksVB = new ValueBox(dedTimeWeeks, dedTimeLock, true, true);
     }
 }
 

--- a/strings.js
+++ b/strings.js
@@ -354,6 +354,21 @@ const STRINGS = {
                 en: "\uD83E\uDDEE",
                 fi: "\uD83E\uDDEE"
         },
+        pen_icon: {
+                sv: "\u270E", // pencil
+                en: "\u270E",
+                fi: "\u270E"
+        },
+        calc_tooltip: {
+                sv: "Använd beräknat värde",
+                en: "Use calculated value",
+                fi: "Käytä laskettua arvoa"
+        },
+        pen_tooltip: {
+                sv: "Skriv in manuellt",
+                en: "Enter manually",
+                fi: "Syötä käsin"
+        },
         calc_help: {
                 sv: "Markerad: använd beräknade eller förinställda värden.<br>Avmarkerad: ange manuellt",
                 en: "Checked: use calculated or preset values.<br>Unchecked: enter values manually",


### PR DESCRIPTION
## Summary
- use one lock button for the three time inputs
- display calculator when locked and pencil when unlocked
- add tooltip text and aria labels for deduction lock buttons

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68500a01c07483289dc22b73e06dd2ab