### PR TITLE
Add time-unit strings and move dedTime lock

### DIFF
--- a/energy.html
+++ b/energy.html
@@ -149,9 +149,10 @@
     </span>
     <br />
     <label for="dedTimeHours" id="lbl_dedTime"><span id="dedTime_label"></span></label>
-    <span class="value-box"><input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"><button id="dedTimeLock" type="button" class="lock-icon" aria-label="Toggle lock"></button></span> <span class="time-unit">h/d</span>
-    <span class="value-box"><input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"></span> <span class="time-unit">d/v</span>
-    <span class="value-box"><input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"></span> <span class="time-unit">v/år</span>
+    <span class="value-box"><input type="number" id="dedTimeHours" value="14" step="any" style="width:4rem;"></span> <span class="time-unit" id="dedTime_hours_unit"></span>
+    <span class="value-box"><input type="number" id="dedTimeDays" value="7" step="any" style="width:4rem;"></span> <span class="time-unit" id="dedTime_days_unit"></span>
+    <span class="value-box"><input type="number" id="dedTimeWeeks" value="52" step="any" style="width:4rem;"></span> <span class="time-unit" id="dedTime_weeks_unit"></span>
+    <button id="dedTimeLock" type="button" class="lock-icon" aria-label="Toggle lock"></button>
 </details>
 
                                 <details class="input-section" open>

--- a/strings.js
+++ b/strings.js
@@ -121,7 +121,22 @@ const STRINGS = {
                 en: "Time (h/d/w):",
                 fi: "Aika (h/p/v):"
         },
-	// Footnotes heading + labels
+        dedTime_hours_unit: {
+                sv: "h/d",
+                en: "h/d",
+                fi: "h/p"
+        },
+        dedTime_days_unit: {
+                sv: "d/v",
+                en: "d/w",
+                fi: "p/v"
+        },
+        dedTime_weeks_unit: {
+                sv: "v/år",
+                en: "w/yr",
+                fi: "v/v"
+        },
+        // Footnotes heading + labels
 	footnotes_heading: {
 		sv: "Extra ventilationsfotnoter (endast flerbostadshus):",
 		en: "Extra ventilation footnotes (only multi‐family):",


### PR DESCRIPTION
## Summary
- localize units for the time deduction fields
- move the deduction time lock button to the end of the row

## Testing
- `bash run_tests.sh` *(fails: 4 JS tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68500eb1c98c83289e12681491d628a4