### PR TITLE
Fix EPpet arrow orientation

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -599,7 +599,7 @@ function calculate() {
                 arrow.textContent = cls;
                 const tri = document.createElement("div");
                 tri.className = "triangle";
-                tri.style.borderLeftColor = color;
+                tri.style.borderRightColor = color;
                 arrow.appendChild(tri);
                 epArrow.appendChild(arrow);
         }

--- a/style.css
+++ b/style.css
@@ -397,11 +397,11 @@ button:hover,
 
 .ep-arrow .triangle {
   position: absolute;
-  right: -29px;
+  left: -29px;
   top: 0;
   width: 0;
   height: 0;
   border-top: 15px solid transparent;
   border-bottom: 15px solid transparent;
-  border-left: 30px solid transparent;
+  border-right: 30px solid transparent;
 }


### PR DESCRIPTION
## Summary
- correct direction of EPpet arrow in main interface

## Testing
- `gcc -o dev/tests dev/tests.c -lm`
- `./dev/tests > test_output.txt`
- `node js_tests.js > test_js_output.txt` *(fails: 4 JS TESTS FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_685163743c208328beed0c19e6cd5899