### PR TITLE
Update 'no requirement' sentinel

### DIFF
--- a/dev/energy.c
+++ b/dev/energy.c
@@ -148,7 +148,7 @@ typedef struct {
 //============================
 //=Helper Functions============
 //============================
-#define NoReq  9999.0
+#define NoReq  999999999.0
 #define seSec  -1.0
 
 D elBase(D F_geo) { R (4.5 + 1.7 * (F_geo - 1.0)); }

--- a/energy.js
+++ b/energy.js
@@ -155,7 +155,7 @@ class LimitVals {
 //============================
 //=Helper Functions============
 //============================
-const NoReq = 9999.0;
+const NoReq = 999999999.0;
 const seSec = -1.0;
 
 function elBase(F_geo) {

--- a/glue.js
+++ b/glue.js
@@ -606,8 +606,8 @@ function calculate() {
 
 
 	// --- populate limits table ---
-	let epLimitDisp = (lim.EP === 9999) ? getString("no_requirement") : lim.EP.toFixed(1);
-	let elLimitDisp = (lim.EL === 9999) ? getString("no_requirement") : lim.EL.toFixed(1);
+	let epLimitDisp = (lim.EP === 999999999) ? getString("no_requirement") : lim.EP.toFixed(1);
+	let elLimitDisp = (lim.EL === 999999999) ? getString("no_requirement") : lim.EL.toFixed(1);
 	let umLimitDisp = lim.UM.toFixed(2);
 
 	// LL: dash + toggle if -1, else the number

--- a/strings.js
+++ b/strings.js
@@ -301,7 +301,7 @@ const STRINGS = {
 		fi: "Ylittää rajan"
 	},
 
-	// “No requirement” literal to replace 9999
+	// “No requirement” literal to replace 999999999
 	no_requirement: {
 		sv: "Inget krav",
 		en: "No requirement",


### PR DESCRIPTION
## Summary
- adjust sentinel for no requirement values to a much larger number
- keep display text for `no_requirement` unchanged

## Testing
- `node -c energy.js`
- `node -c glue.js`
- `node -c strings.js`
- `node -c energyprint.js`

------
https://chatgpt.com/codex/tasks/task_e_6853ada7664483288803bbfcfcb0bb69