### PR TITLE
Improve filename generation for new energy printer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,5 @@
 - Help tooltips appear and disappear abruptly by design. Please do not add
   animations or transitions.
 - Limited location options are intentional and match the available factors in Åland's regulations.
+
+- Avoid "magic" numbers or strings in scripts. Declare descriptive constants for values that may be adjusted or reused.

--- a/energyprint_new.html
+++ b/energyprint_new.html
@@ -187,6 +187,43 @@
 
   <script src="epclass.js"></script>
   <script>
+    const ADDRESS_LIMIT = 80;
+    const MAX_FILENAME_LENGTH = 100;
+
+    function generateName(address, id) {
+      // Normalize to NFD so diacritics become separate codepoints and then
+      // strip them (\u0300-\u036f matches combining marks). We also map
+      // common Å, Ä, Ö characters to plain a/o for local audience.
+      const translit = str =>
+        str.normalize('NFD')
+           .replace(/[\u0300-\u036f]/g, '')
+           .replace(/[åäÅÄ]/g, 'a')
+           .replace(/[öÖ]/g, 'o');
+
+      const sanitize = str =>
+        translit(str)
+          .replace(/\s+/g, '_')
+          .replace(/[^0-9A-Za-z_-]/g, '');
+
+      const safeId = sanitize(String(id || ''));
+      let safeAddr = sanitize(String(address || '')); 
+      if (safeAddr.length > ADDRESS_LIMIT) safeAddr = safeAddr.slice(0, ADDRESS_LIMIT);
+
+      let base = `energideklaration-${safeId}-${safeAddr}`;
+      if (base.length + 4 > MAX_FILENAME_LENGTH) {
+        const excess = base.length + 4 - MAX_FILENAME_LENGTH;
+        base = base.slice(0, base.length - excess);
+      }
+      return base + '.pdf';
+    }
+
+    function updateFileName() {
+      const address = document.getElementById('addressInput').value;
+      const id = document.getElementById('idInput').value;
+      const name = generateName(address, id);
+      document.title = name;
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       const labels = Object.keys(window.EPClass.data);
       const colors = labels.map(l => window.EPClass.data[l].colour);
@@ -310,6 +347,7 @@
       }
 
       function updateAll(){
+        updateFileName();
         computeClass();
         drawVisuals();
         updatePreview();


### PR DESCRIPTION
## Summary
- refine `generateName` sanitization comments
- limit address part to 80 chars and total filename to 100
- remove redundant PDF stripping in title update
- define constants for filename limits
- document avoiding magic values

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853b2891b8883289c2cb68fa70c4e9b