### PR TITLE
Introduce central config

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,43 @@
+(function(){
+  const CONFIG = {
+    CONSTANTS: {
+      PERSON_HEAT: 80,
+      NOREQ_VALUE: 999999999,
+      LOCKED_COMBINATIONS: []
+    },
+    FEATURES: {
+      NOREQ_NACLASS: true
+    },
+    PRINTING: {
+      NAME_LIMITS: {
+        ADDRESS: 80,
+        FILENAME: 100
+      },
+      CLASS_LAYOUT: {
+        container: { width:73, height:90 },
+        margins: { top:10, bottom:5, gap:3 },
+        arrow: { minNorm:0.2, maxNorm:0.9, fontSize:5 },
+        letterOffset: { x:-4, y:0.5 },
+        outline: { black:2.5, white:1 },
+        house: { roofThickness:9, roofGap:6, fontSize:50, letterOffset: { x:0, y:20 } }
+      }
+    },
+    EP_TABLE: {
+      A: { range: [0, 0.5], colour: '#2ac02c', width: '20%' },
+      B: { range: [0.5, 0.75], colour: '#6cc04a', width: '30%' },
+      C: { range: [0.75, 1.0], colour: '#dbdb29', width: '40%' },
+      D: { range: [1.0, 1.35], colour: '#f0b928', width: '50%' },
+      E: { range: [1.35, 1.8], colour: '#f08d1c', width: '60%' },
+      F: { range: [1.8, 2.35], colour: '#e65400', width: '70%' },
+      G: { range: [2.35, Infinity], colour: '#d90000', width: '80%' }
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    window.CONFIG = CONFIG;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = CONFIG;
+  }
+})();

--- a/energy.html
+++ b/energy.html
@@ -6,6 +6,7 @@
 		<title>Energy</title>
 		<link rel="stylesheet" href="style.css">
                 <script src="strings.js"></script>
+                <script src="config.js"></script>
                 <script src="energy.js"></script>
                 <script src="epclass.js"></script>
                 <script src="glue.js" defer ></script>

--- a/energy.js
+++ b/energy.js
@@ -62,12 +62,6 @@ const TvvMult = [
   /* LOCAL */ 2
 ];
 
-const PERSON_HEAT = 80; // watts
-// Expose for UI defaults when running in the browser
-if (typeof window !== 'undefined') {
-  window.PERSON_HEAT = PERSON_HEAT;
-}
-
 //============================
 //=Location===================
 //============================

--- a/energyprint_new.html
+++ b/energyprint_new.html
@@ -186,9 +186,8 @@
   </div>
 
   <script src="epclass.js"></script>
+  <script src="config.js"></script>
   <script>
-    const ADDRESS_LIMIT = 80;
-    const MAX_FILENAME_LENGTH = 100;
 
     function generateName(address, id) {
       // Normalize to NFD so diacritics become separate codepoints and then
@@ -207,11 +206,13 @@
 
       const safeId = sanitize(String(id || ''));
       let safeAddr = sanitize(String(address || '')); 
-      if (safeAddr.length > ADDRESS_LIMIT) safeAddr = safeAddr.slice(0, ADDRESS_LIMIT);
+      if (safeAddr.length > CONFIG.PRINTING.NAME_LIMITS.ADDRESS) {
+        safeAddr = safeAddr.slice(0, CONFIG.PRINTING.NAME_LIMITS.ADDRESS);
+      }
 
       let base = `energideklaration-${safeId}-${safeAddr}`;
-      if (base.length + 4 > MAX_FILENAME_LENGTH) {
-        const excess = base.length + 4 - MAX_FILENAME_LENGTH;
+      if (base.length + 4 > CONFIG.PRINTING.NAME_LIMITS.FILENAME) {
+        const excess = base.length + 4 - CONFIG.PRINTING.NAME_LIMITS.FILENAME;
         base = base.slice(0, base.length - excess);
       }
       return base + '.pdf';
@@ -227,19 +228,18 @@
     document.addEventListener('DOMContentLoaded', () => {
       const labels = Object.keys(window.EPClass.data);
       const colors = labels.map(l => window.EPClass.data[l].colour);
-      const FEATURE_NOREQ_NACLASS = true;
-      const NOREQ_VALUE = 999999999;
       let noReq = false;
+      const base = CONFIG.PRINTING.CLASS_LAYOUT;
       const config = {
         labels,
         colors,
         highlightIdx: 0,
-        container: { width:73, height:90 },
-        margins: { top:10, bottom:5, gap:3 },
-        arrow: { minNorm:0.2, maxNorm:0.9, fontSize:5 },
-        letterOffset: { x:-4, y:0.5 },
-        outline: { black:2.5, white:1 },
-        house: { roofThickness:9, roofGap:6, fontSize:50, letterOffset: { x:0, y:20 } }
+        container: base.container,
+        margins: base.margins,
+        arrow: base.arrow,
+        letterOffset: base.letterOffset,
+        outline: base.outline,
+        house: base.house
       };
       // Bind inputs to displays
       const bind = (inputId, displayId) => {
@@ -247,8 +247,8 @@
         const disp = document.getElementById(displayId);
         const setDisp = () => {
           let val = inp.value;
-          if (FEATURE_NOREQ_NACLASS && inputId === 'requirementInput' &&
-              parseFloat(val) >= NOREQ_VALUE) {
+          if (CONFIG.FEATURES.NOREQ_NACLASS && inputId === 'requirementInput' &&
+              parseFloat(val) >= CONFIG.CONSTANTS.NOREQ_VALUE) {
             disp.textContent = 'N/A';
           } else {
             disp.textContent = val;
@@ -353,7 +353,7 @@
 
       function computeClass() {
         const limRaw = parseFloat(document.getElementById('requirementInput').value);
-        noReq = FEATURE_NOREQ_NACLASS && !isNaN(limRaw) && limRaw >= NOREQ_VALUE;
+        noReq = CONFIG.FEATURES.NOREQ_NACLASS && !isNaN(limRaw) && limRaw >= CONFIG.CONSTANTS.NOREQ_VALUE;
         if (noReq) return;
         const ep = parseFloat(document.getElementById('energyInput').value);
         const cls = window.EPClass.classify(ep, limRaw);

--- a/epclass.js
+++ b/epclass.js
@@ -1,14 +1,15 @@
 (function(){
+  const defaultData = {
+    A: { range: [0, 0.5], colour: '#2ac02c', width: '20%' },
+    B: { range: [0.5, 0.75], colour: '#6cc04a', width: '30%' },
+    C: { range: [0.75, 1.0], colour: '#dbdb29', width: '40%' },
+    D: { range: [1.0, 1.35], colour: '#f0b928', width: '50%' },
+    E: { range: [1.35, 1.8], colour: '#f08d1c', width: '60%' },
+    F: { range: [1.8, 2.35], colour: '#e65400', width: '70%' },
+    G: { range: [2.35, Infinity], colour: '#d90000', width: '80%' }
+  };
   const EPClass = {
-    data: {
-      A: { range: [0, 0.5], colour: '#2ac02c', width: '20%' },
-      B: { range: [0.5, 0.75], colour: '#6cc04a', width: '30%' },
-      C: { range: [0.75, 1.0], colour: '#dbdb29', width: '40%' },
-      D: { range: [1.0, 1.35], colour: '#f0b928', width: '50%' },
-      E: { range: [1.35, 1.8], colour: '#f08d1c', width: '60%' },
-      F: { range: [1.8, 2.35], colour: '#e65400', width: '70%' },
-      G: { range: [2.35, Infinity], colour: '#d90000', width: '80%' }
-    },
+    data: (typeof CONFIG !== 'undefined' && CONFIG.EP_TABLE) ? CONFIG.EP_TABLE : defaultData,
     values(eplim){
       const out = {};
       for(const [k,v] of Object.entries(this.data)){

--- a/glue.js
+++ b/glue.js
@@ -40,7 +40,9 @@ const table = $("energyTable");
 const ROOMS_TO_PERSONS = [1.42, 1.63, 2.18, 2.79, 3.51];
 
 // Lock improbable energy source combinations (none currently)
-const LOCKED_COMBINATIONS = [];
+const LOCKED_COMBINATIONS = (typeof CONFIG !== 'undefined' && CONFIG.CONSTANTS && CONFIG.CONSTANTS.LOCKED_COMBINATIONS)
+  ? CONFIG.CONSTANTS.LOCKED_COMBINATIONS
+  : [];
 window.LOCKED_COMBINATIONS = LOCKED_COMBINATIONS;
 
 function personsFromRooms(n) {
@@ -688,7 +690,8 @@ function prefillFromURL() {
         if (tvvSel) tvvSel.value = params.get("tvv") || "0";
 
         // deduction defaults
-        const perHeatDef = params.get("perheat") || (typeof PERSON_HEAT !== 'undefined' ? PERSON_HEAT : "");
+        const perHeatDef = params.get("perheat") ||
+          (typeof CONFIG !== 'undefined' && CONFIG.CONSTANTS ? CONFIG.CONSTANTS.PERSON_HEAT : "");
         if (dedPersonHeatVB) dedPersonHeatVB.setCalc(perHeatDef);
         if (dedTimeHoursVB) dedTimeHoursVB.setCalc(dedTimeHours.value);
         if (dedTimeDaysVB) dedTimeDaysVB.setCalc(dedTimeDays.value);


### PR DESCRIPTION
## Summary
- expand `config.js` to group constants, feature flags and printing layout
- centralize A–G class ranges and colours via `EP_TABLE`
- reference new config paths in scripts
- move filename limits under printing configuration
- reference CONFIG for person heat defaults

## Testing
- `node -e "require('./energy.js');"`
- `node -e "require('./config.js');"`
- `node -e "require('./glue.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6853b9dd4acc8328b69bcc7ef5f57520