### PR TITLE
Switch permalink copy to Clipboard API

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -309,13 +309,25 @@ function registerListeners(){
             window.location.href = `energyprint_new.html?ep=${epv}&housetype=${type.value}&eplim=${eplim}`;
         });
 	//copy
-	copy.addEventListener("click",()=>{
-		const ta=$("permalink");
-		ta.select(); ta.setSelectionRange(0,99999);
-		document.execCommand("copy");
-		copy.textContent=getString("copy_button")+" ✔";
-		setTimeout(()=>copy.textContent=getString("copy_button"),1500);
-	});
+        copy.addEventListener("click", () => {
+                const ta = $("permalink");
+                const text = ta.value;
+                const done = () => {
+                        copy.textContent = getString("copy_button") + " ✔";
+                        setTimeout(() => copy.textContent = getString("copy_button"), 1500);
+                };
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(text).then(done).catch(() => {
+                                ta.select(); ta.setSelectionRange(0, 99999);
+                                document.execCommand("copy");
+                                done();
+                        });
+                } else {
+                        ta.select(); ta.setSelectionRange(0, 99999);
+                        document.execCommand("copy");
+                        done();
+                }
+        });
 }
 
 


### PR DESCRIPTION
## Summary
- use the Clipboard API when copying the permalink
- fall back to `execCommand` if the API is unavailable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853e0218bb88328b953765d6f5ffc62