### PR TITLE
Fix duplicate help-box styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,15 +146,6 @@ textarea#permalink {
   margin-bottom: 0.5rem;
 }
 
-.help-box {
-  background: #eef;
-  border: 0.06rem solid #99c;
-  padding: 0.4rem;
-  font-size: 0.85rem;
-  margin-top: 0.25rem;
-  display: none;
-  white-space: normal;
-}
 
 .info-icon {
   color: blue;
@@ -295,6 +286,10 @@ button:hover {
   background: var(--help-bg);
   border: 1px solid var(--help-border);
   padding: 0.4rem;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+  display: none;
+  white-space: normal;
 }
 
 /* Tables inside help text should size to content */


### PR DESCRIPTION
## Summary
- remove the early duplicate `.help-box` block
- extend the remaining rule with the needed properties

## Testing
- `node energy.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6853dfec792c83288527daaab2b88ea2