### PR TITLE
Adjust footer padding and show URL

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -270,6 +270,7 @@ function applyLanguage() {
         const repoLink = $("footer_repo_link");
         if (repoLink && typeof CONFIG !== "undefined" && CONFIG.APP_INFO) {
                 repoLink.href = CONFIG.APP_INFO.REPO_URL;
+                repoLink.textContent = CONFIG.APP_INFO.REPO_URL;
         }
         const verEl = $("app_version");
         if (verEl && typeof CONFIG !== "undefined" && CONFIG.APP_INFO) {

--- a/strings.js
+++ b/strings.js
@@ -475,6 +475,6 @@ const PRINT_STRINGS = {
         suggestions_label: { sv: "Åtgärdsförslag:", en: "Proposed measures:", fi: "Toimenpide-ehdotukset:" },
         performed_label:   { sv: "Energideklarationen är utförd av:", en: "Declaration performed by:", fi: "Energiatodistuksen on laatinut:" },
         valid_label:       { sv: "Energideklarationen är giltig till:", en: "Declaration valid until:", fi: "Energiatodistus voimassa asti:" },
-        footer_repo_label:  { sv: "Källkod:", en: "Source:", fi: "Lähdekoodi:" },
+        footer_repo_label:  { sv: "Källkod:", en: "Source code:", fi: "Lähdekoodi:" },
         footer_version_label:{ sv: "Version:", en: "Version:", fi: "Versio:" }
 };

--- a/style.css
+++ b/style.css
@@ -414,7 +414,7 @@ footer#appFooter {
   background: var(--form-bg);
   width: 100%;
   box-sizing: border-box;
-  padding: 0.5rem 0;
+  padding: 0.5rem 0.25rem;
 }
 
 #footerDivider {


### PR DESCRIPTION
## Summary
- show the repository URL itself in the footer
- clarify English footer label text
- loosen footer padding slightly

## Testing
- `node --check glue.js`
- `node --check strings.js`


------
https://chatgpt.com/codex/tasks/task_e_6853e43d65508328bf33b75792dd2000