### PR TITLE
Update EP row style with ratio arrow

### DIFF
--- a/src/energy.html
+++ b/src/energy.html
@@ -187,12 +187,19 @@
 			</form>
 
                         <div id="results">
-                                <h2 id="ep_label" style="display:inline;"></h2>
-                                <span id="ep_arrow"></span>
+                                <table id="epRowTable">
+                                        <tr>
+                                                <th id="ep_label"></th>
+                                                <td>
+                                                        <span id="ep_value"></span>
+                                                        <span id="ep_arrow"></span>
+                                                </td>
+                                        </tr>
+                                </table>
 
                                 <h3 id="upper_limits_heading" ></h3>
-				<p id="upperLimitLabel" style="margin-top: 1rem; font-weight: bold;"></p>
-				<table id="limitsTable"></table>
+                                <p id="upperLimitLabel" style="margin-top: 1rem; font-weight: bold;"></p>
+                                <table id="limitsTable"></table>
 
 				<div style="text-align: center; margin-top: 1rem;">
 					<button id="print_button" style="padding: 0.4rem 0.8rem; font-size: 0.9rem; cursor: pointer;"> </button>

--- a/src/glue.js
+++ b/src/glue.js
@@ -38,9 +38,13 @@ const foot3Lbl    = $("lbl_foot3");
 const foot4Lbl    = $("lbl_foot4");
 const foot5Lbl    = $("lbl_foot5");
 const outEP    = $("ep_label"), limitsT  = $("limitsTable");
+const epValue  = $("ep_value");
 const epArrow  = $("ep_arrow");
 const table = $("energyTable");
 const ROOMS_TO_PERSONS = [1.42, 1.63, 2.18, 2.79, 3.51];
+
+const ARROW_LENGTH_IN = 0.5;
+const ARROW_LENGTH = `${ARROW_LENGTH_IN}in`;
 
 // Lock improbable energy source combinations (none currently)
 const LOCKED_COMBINATIONS = (typeof CONFIG !== 'undefined' && CONFIG.CONSTANTS && CONFIG.CONSTANTS.LOCKED_COMBINATIONS)
@@ -638,20 +642,22 @@ function calculate() {
         const lim = limit(h);
         window.last_eplim = lim.EP;
 
+        outEP.textContent = getString("ep_label");
         if (epv > lim.EP) {
-                outEP.innerHTML = `${getString("ep_label")} ${epv} <span class="warning-icon" title="${getString("warning_tooltip")}">⚠</span>`;
+                epValue.innerHTML = `${epv} <span class="warning-icon" title="${getString("warning_tooltip")}">⚠</span>`;
         } else {
-                outEP.innerHTML = `${getString("ep_label")} ${epv}`;
+                epValue.textContent = epv;
         }
 
         epArrow.innerHTML = "";
         const cls = window.EPClass.classify(epv, lim.EP);
-        if(cls){
+        if (cls) {
                 const color = window.EPClass.data[cls].colour;
                 const arrow = document.createElement("div");
                 arrow.className = "ep-arrow";
                 arrow.style.backgroundColor = color;
-                arrow.textContent = cls;
+                arrow.style.width = ARROW_LENGTH;
+                arrow.textContent = `${cls} (${epv}/${Math.round(lim.EP)})`;
                 const tri = document.createElement("div");
                 tri.className = "triangle";
                 tri.style.borderRightColor = color;

--- a/src/style.css
+++ b/src/style.css
@@ -235,6 +235,23 @@ button.copy-btn {
   white-space: nowrap;
 }
 
+#epRowTable {
+  border-collapse: collapse;
+  margin-bottom: 0.5rem;
+  width: 100%;
+  table-layout: fixed;
+}
+
+#epRowTable th,
+#epRowTable td {
+  padding: 0.2rem 0.5rem;
+  border: 0.06rem solid #ccc;
+  font-size: 0.9rem;
+  text-align: left;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 /*----------------------------------*/
 
 


### PR DESCRIPTION
## Summary
- show EPpet row in a small table
- add arrow ratio and length constant
- style EP row table like limits table

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6853ec55e37c8328bc6f7a0a1d1d3946