### PR TITLE
Deprecate legacy print template

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ text on click.
 | Filename              | Description |
 |-----------------------|--------------------------------------------------------------|
 | `src/energy.html`      | Main webpage for user interaction |
-| `src/energyprint.html` | A page to print out energy certificate thingie |
+| `src/energyprint_new.html` | Maintained print-friendly layout |
+| `src/energyprint.html` | Deprecated print template |
 | `src/energy.js`        | Core calculation logic|
 | `src/glue.js`          | Controls the DOM and ui. |
 | `src/strings.js`       | User facing strings and translations |

--- a/src/energyprint.html
+++ b/src/energyprint.html
@@ -1,5 +1,6 @@
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <!-- Copyright (C) 2025 Edvin svenblad -->
+<!-- DEPRECATED: Use energyprint_new.html instead -->
 
 <!DOCTYPE html>
 <html lang="sv">
@@ -234,6 +235,9 @@
     </style>
   </head>
   <body>
+    <div style="background:#fffae6;border:1px solid #e0a000;padding:1em;margin:1em;text-align:center;">
+      Denna fil är föråldrad. Använd <a href="energyprint_new.html">energyprint_new.html</a> istället.
+    </div>
     <!-- Title -->
     <fieldset class="box">
       <h1 style="text-align:center; color: var(--primary-green); margin:0;">

--- a/src/energyprint_new.html
+++ b/src/energyprint_new.html
@@ -369,6 +369,20 @@
         }
       }
 
+      const typeMap = {
+        SMALL: 'option_housetype_SMALL',
+        MULTI: 'option_housetype_MULTI',
+        LOCAL: 'option_housetype_LOCAL'
+      };
+      const typeParam = (params.get('housetype') || '').toUpperCase();
+      const typeKey = typeMap[typeParam];
+      if (typeKey) {
+        const clsHead = document.getElementById('p_classes_heading');
+        if (clsHead) {
+          clsHead.textContent += ' – ' + getString(typeKey);
+        }
+      }
+
       const roof = document.getElementById('houseRoof'), body = document.getElementById('houseBody');
       const rt = config.house.roofThickness, rg = config.house.roofGap;
       roof.setAttribute('points', [[0,50],[50,0],[100,50],[100-rt,50],[50,rt],[rt,50]].map(p=>p.join(',')).join(' '));


### PR DESCRIPTION
## Summary
- mark `energyprint.html` as deprecated and display banner
- highlight `energyprint_new.html` as the maintained print view in README
- show building type on the new print page when provided via URL parameter

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6859356fcbe88328b2bb6ba74a5fad96