### PR TITLE
Localization for placeholders

### DIFF
--- a/src/energyprint.html
+++ b/src/energyprint.html
@@ -398,7 +398,7 @@ margin-left: calc(8em + 0.5em);
     </fieldset>
 
     <!-- Print Button -->
-    <button id="printButton" onclick="window.print()">Skriv ut</button>
+    <button id="printButton" onclick="window.print()"></button>
 
     <script src="config.js"></script>
     <script src="energyprint.js"></script>

--- a/src/energyprint_new.html
+++ b/src/energyprint_new.html
@@ -94,31 +94,31 @@
     <div id="dataEntry">
       <div class="input-section">
         <label id="lbl_p_address" for="addressInput"></label>
-        <input type="text" id="addressInput" placeholder="Oceangränd 1 B2">
+        <input type="text" id="addressInput">
         <label id="lbl_p_municipality" for="municipalityInput"></label>
-        <input type="text" id="municipalityInput" placeholder="Jomala kommun">
+        <input type="text" id="municipalityInput">
         <label id="lbl_p_year" for="yearInput"></label>
-        <input type="text" id="yearInput" placeholder="t.ex. 2009">
+        <input type="text" id="yearInput">
         <label id="lbl_p_id" for="idInput"></label>
-        <input type="text" id="idInput" placeholder="t.ex. 3671">
+        <input type="text" id="idInput">
         <label id="lbl_p_energy" for="energyInput"></label>
-        <input type="text" id="energyInput" placeholder="t.ex. 162">
+        <input type="text" id="energyInput">
         <label id="lbl_p_requirement" for="requirementInput"></label>
-        <input type="text" id="requirementInput" placeholder="100 kWh/m² och år">
+        <input type="text" id="requirementInput">
         <label id="lbl_p_heating" for="heatingInput"></label>
-        <input type="text" id="heatingInput" placeholder="Värmepump-luft/luft (el) och el">
+        <input type="text" id="heatingInput">
         <label id="lbl_p_radon" for="radonInput"></label>
-        <input type="text" id="radonInput" placeholder="Inte utförd">
+        <input type="text" id="radonInput">
         <label id="lbl_p_ovk" for="ovkInput"></label>
-        <input type="text" id="ovkInput" placeholder="Utförd">
+        <input type="text" id="ovkInput">
         <label id="lbl_p_suggestions" for="suggestionsInput"></label>
-        <input type="text" id="suggestionsInput" placeholder="Har lämnats">
+        <input type="text" id="suggestionsInput">
         <label id="lbl_p_performed" for="performedInput"></label>
-        <input type="text" id="performedInput" placeholder="Namn Efternamn, LL, 2025-05-27">
+        <input type="text" id="performedInput">
         <label id="lbl_p_valid" for="validInput"></label>
-        <input type="text" id="validInput" placeholder="2035-05-27">
+        <input type="text" id="validInput">
       </div>
-      <button id="printButton" onclick="window.print()">Skriv ut</button>
+      <button id="printButton" onclick="window.print()"></button>
     </div>
     <div id="previewContainer"><div id="previewContent"></div></div>
   </div>

--- a/src/strings.js
+++ b/src/strings.js
@@ -448,8 +448,8 @@ const PRINT_UI_STRINGS = {
         performed_label:  { sv: "Energideklarationen är utförd av:", en: "Declaration performed by:", fi: "Energiatodistuksen on laatinut:" },
         valid_label:      { sv: "Energideklarationen är giltig till:", en: "Declaration valid until:", fi: "Energiatodistus voimassa asti:" },
 
-        address_placeholder:     { sv: "Oceangränd 1 B2", en: "Oceangränd 1 B2", fi: "Oceangränd 1 B2" },
-        municipality_placeholder:{ sv: "Jomala kommun", en: "Jomala kommun", fi: "Jomala kommun" },
+        address_placeholder:     { sv: "Gatunamn", en: "Street name", fi: "Katuosoite" },
+        municipality_placeholder:{ sv: "kommun", en: "municipality", fi: "kunta" },
         year_placeholder:        { sv: "t.ex. 2009", en: "e.g. 2009", fi: "esim. 2009" },
         id_placeholder:          { sv: "t.ex. 3671", en: "e.g. 3671", fi: "esim. 3671" },
         energy_placeholder:      { sv: "t.ex. 162", en: "e.g. 162", fi: "esim. 162" },


### PR DESCRIPTION
## Summary
- localize sample address and municipality placeholders using neutral terms
- remove Swedish text from deprecated print button

## Testing
- `node -e "require('jsdom');"` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685a501ef9308328855e3e2682013a72