### PR TITLE
Switch copy to async clipboard API

### DIFF
--- a/src/glue.js
+++ b/src/glue.js
@@ -195,14 +195,10 @@ function hookCopy() {
         };
         if (navigator.clipboard && navigator.clipboard.writeText) {
                 navigator.clipboard.writeText(text).then(done).catch(() => {
-                        ta.select(); ta.setSelectionRange(0, 99999);
-                        document.execCommand("copy");
-                        done();
+                        alert(getString("clipboard_error"));
                 });
         } else {
-                ta.select(); ta.setSelectionRange(0, 99999);
-                document.execCommand("copy");
-                done();
+                alert(getString("clipboard_error"));
         }
 }
 

--- a/src/strings.js
+++ b/src/strings.js
@@ -257,6 +257,11 @@ const STRINGS = {
                 en: "Copy Link",
                 fi: "Kopioi linkki"
         },
+        clipboard_error: {
+                sv: "Urklipp inte tillgängligt, kopiera manuellt.",
+                en: "Clipboard unavailable, please copy manually.",
+                fi: "Leikepöytä ei käytettävissä, kopioi käsin."
+        },
         hourly_label: {
                 sv: "Använd timvis simulering",
                 en: "Use hourly simulation",


### PR DESCRIPTION
## Summary
- remove document.execCommand usage
- use asynchronous Clipboard API only
- show a localized error when clipboard access fails

## Testing
- `grep -R "execCommand" -n`

------
https://chatgpt.com/codex/tasks/task_e_685a8e46c6f8832899d73aee3fe1806e