### PR TITLE
Fix print colors in high contrast mode

### DIFF
--- a/src/energyprint_new.html
+++ b/src/energyprint_new.html
@@ -69,10 +69,13 @@
         padding: 0;
         font-family: Arial, sans-serif;
         font-size: 10pt;
+        background: #fff;
         -webkit-print-color-adjust: exact;
         color-adjust: exact;
+        forced-color-adjust: none;
       }
-      #printArea { display: block; }
+      #printArea { display: block; forced-color-adjust: none; }
+      #printArea * { forced-color-adjust: none; }
       .container { border: none !important; page-break-inside: avoid; }
       .classes-box { border: 1px solid #000 !important; }
     }


### PR DESCRIPTION
## Summary
- keep print area white in high-contrast mode
- prevent forced color adjustments from overriding print styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ba1f7df8c83288259bd8f8240c6cc