### PR TITLE
Fix print button default text

### DIFF
--- a/src/energy.html
+++ b/src/energy.html
@@ -205,7 +205,7 @@
                                 <table id="limitsTable"></table>
 
 				<div style="text-align: center; margin-top: 1rem;">
-					<button id="print_button" style="padding: 0.4rem 0.8rem; font-size: 0.9rem; cursor: pointer;"> </button>
+					<button id="print_button" style="padding: 0.4rem 0.8rem; font-size: 0.9rem; cursor: pointer;">Print</button>
 				</div>
                         </div>
 


### PR DESCRIPTION
## Summary
- add `Print` as fallback text in the main print button

## Testing
- `grep -n "print_button" src/energy.html`

------
https://chatgpt.com/codex/tasks/task_e_685baa267d408328ae99c2198a965e43