### PR TITLE
Add ARIA attributes for help icon toggle

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -53,10 +53,14 @@
       icon.title = '';
       icon.setAttribute('aria-label', getString('help_icon_label'));
       icon.setAttribute('role', 'button');
+      icon.setAttribute('aria-controls', boxId);
+      icon.setAttribute('aria-expanded', 'false');
       icon.tabIndex = 0;
       const toggle = () => {
+        const shouldShow = box.style.display !== 'block';
         box.innerHTML = txt;
-        box.style.display = box.style.display === 'block' ? 'none' : 'block';
+        box.style.display = shouldShow ? 'block' : 'none';
+        icon.setAttribute('aria-expanded', shouldShow ? 'true' : 'false');
       };
       icon.onclick = toggle;
       icon.addEventListener('keydown', ev => {


### PR DESCRIPTION
## Summary
- update `setupHelp` to set `aria-controls` and toggle `aria-expanded`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bc1fb00e08328823a8acc1bfb4e0a