### PR TITLE
Fix deduction layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -216,7 +216,9 @@ textarea#permalink {
 }
 
 .ded-pair {
-  white-space: nowrap;
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 


### PR DESCRIPTION
## Summary
- allow the `ded-pair` element to wrap so Personvärme does not overflow on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bc8ee859483289e85eb38d269306d