### PR TITLE
Improve energy table layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -126,6 +126,13 @@ form#houseForm table td {
   max-width: 4rem;
 }
 
+/* Keep narrow columns readable on small screens */
+#energyTable th,
+#energyTable td {
+  padding: 0.15rem;
+  min-width: 3.5rem;
+}
+
 /* Let tables within the form use natural width for their last column
    unless specifically overridden */
 form#houseForm table th:last-child,
@@ -380,12 +387,16 @@ th, td {
 /* Ensure label and calc columns have room for icons */
 #energyTable th:first-child,
 #energyTable td:first-child {
-  min-width: 6rem;
+  min-width: 5rem;
 }
 
 #energyTable th:last-child,
 #energyTable td:last-child {
   width: 3.5rem;
+}
+
+#energyTable .value-box {
+  width: 100%;
 }
 
 /* Energy input table without borders */


### PR DESCRIPTION
## Summary
- tweak `#energyTable` styles so columns stay readable when scrolling
- allow the first column to shrink a bit more
- ensure inputs use full cell width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bc9a8dcd08328a112b97fd3979957