### PR TITLE
Refine table spacing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -118,7 +118,7 @@ form#houseForm table {
 form#houseForm table th,
 form#houseForm table td {
   border: 0.06rem solid #ccc;
-  padding: 0.2rem;
+  padding: 0;
   text-align: center;
   font-size: 0.85rem;
   overflow: hidden;
@@ -129,7 +129,7 @@ form#houseForm table td {
 /* Keep narrow columns readable on small screens */
 #energyTable th,
 #energyTable td {
-  padding: 0.15rem;
+  padding: 0;
   min-width: 3.5rem;
 }
 
@@ -152,6 +152,15 @@ form#houseForm select {
   padding: 0.15rem;
   font-size: 0.9rem;
   box-sizing: border-box;
+}
+
+/* Remove extra spacing for inputs nested in tables */
+#energyInputTable input,
+#energyInputTable select,
+#energyTable input,
+#energyTable select {
+  margin-right: 0;
+  margin-bottom: 0;
 }
 
 /* Collapsible input subsections */
@@ -408,7 +417,7 @@ th, td {
 }
 #energyInputTable td {
   border: none;
-  padding: 0.25rem 0.5rem 0.25rem 0;
+  padding: 0;
 }
 
 /* The input table shouldn't inherit the narrow last column used by


### PR DESCRIPTION
## Summary
- slim down cell padding in tables
- remove extra margins from table inputs
- zero out table cell padding for energy tables

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685bcb436f4c8328b1c7857e38f143f0