### PR TITLE
Adjust EP arrow on small screens

### DIFF
--- a/src/glue.js
+++ b/src/glue.js
@@ -560,6 +560,7 @@ function calculate() {
                 const tri = document.createElement("div");
                 tri.className = "triangle";
                 tri.style.borderRightColor = NA_ARROW_COLOR;
+                tri.style.borderLeftColor = NA_ARROW_COLOR;
                 arrow.appendChild(tri);
                 epArrow.appendChild(arrow);
         } else {
@@ -574,6 +575,7 @@ function calculate() {
                         const tri = document.createElement("div");
                         tri.className = "triangle";
                         tri.style.borderRightColor = color;
+                        tri.style.borderLeftColor = color;
                         arrow.appendChild(tri);
                         epArrow.appendChild(arrow);
                 }

--- a/src/style.css
+++ b/src/style.css
@@ -224,9 +224,20 @@ textarea#permalink {
   #ep_arrow {
     margin-top: 0.25rem;
     flex-basis: 100%;
+    margin-left: 0;
+    margin-right: var(--ep-triangle-width);
   }
   .ep-arrow {
     width: 100%;
+  }
+  .ep-arrow .triangle {
+    left: auto;
+    right: calc(-1 * var(--ep-triangle-width));
+    border-right: none;
+    border-left: var(--ep-triangle-width) solid transparent;
+  }
+  #epRow #ep_value {
+    font-size: 2rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- flip the orientation of the EP class arrow when it wraps
- make the value larger when wrapped
- color arrowhead via both left and right borders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bce71c8688328829b35132215fffb