### PR TITLE
Fix mobile layout overflow

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -48,6 +48,7 @@ main {
 .container {
   max-width: 50rem; /* ~800px */
   width: 100%;
+  box-sizing: border-box;
   flex: 1;
 }
 
@@ -350,6 +351,7 @@ body {
   border: 1px solid var(--border-color);
   padding: 1rem;
   margin-top: 2rem;
+  box-sizing: border-box;
   flex: 1;
 }
 


### PR DESCRIPTION
## Summary
- keep `.container` width within screen bounds by using `box-sizing: border-box`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bcfa6276c8328b95ebf0180f8caba