### PR TITLE
Adjust EP arrow on small screens

### DIFF
--- a/src/glue.js
+++ b/src/glue.js
@@ -560,6 +560,7 @@ function calculate() {
                 const tri = document.createElement("div");
                 tri.className = "triangle";
                 tri.style.borderRightColor = NA_ARROW_COLOR;
+                tri.style.borderLeftColor = NA_ARROW_COLOR;
                 arrow.appendChild(tri);
                 epArrow.appendChild(arrow);
         } else {
@@ -574,6 +575,7 @@ function calculate() {
                         const tri = document.createElement("div");
                         tri.className = "triangle";
                         tri.style.borderRightColor = color;
+                        tri.style.borderLeftColor = color;
                         arrow.appendChild(tri);
                         epArrow.appendChild(arrow);
                 }

--- a/src/style.css
+++ b/src/style.css
@@ -224,9 +224,20 @@ textarea#permalink {
   #ep_arrow {
     margin-top: 0.25rem;
     flex-basis: 100%;
+    margin-left: 0 !important;
+    margin-right: var(--ep-triangle-width) !important;
   }
   .ep-arrow {
-    width: 100%;
+    width: 100% !important;
+  }
+  .ep-arrow .triangle {
+    left: auto !important;
+    right: calc(-1 * var(--ep-triangle-width)) !important;
+    border-right: none !important;
+    border-left: var(--ep-triangle-width) solid transparent !important;
+  }
+  #epRow #ep_value {
+    font-size: 2rem !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- flip orientation and adjust style via `!important` so arrow and value display correctly when the row wraps

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bce71c8688328829b35132215fffb