### PR TITLE
Fix arrow visibility in high contrast

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -521,6 +521,12 @@ button:hover,
   max-width: calc(100% - var(--ep-triangle-width));
 }
 
+@media (forced-colors: active) {
+  .ep-arrow {
+    border: 1px solid CanvasText;
+  }
+}
+
 .ep-arrow .triangle {
   position: absolute;
   left: calc(-1 * var(--ep-triangle-width));


### PR DESCRIPTION
## Summary
- style: add border for EP arrow in high contrast mode

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685be04a17408328973c3a85233eac0e